### PR TITLE
Fix bug with FileLogContext::setFilePath.

### DIFF
--- a/include/ivi-logging-file.h
+++ b/include/ivi-logging-file.h
@@ -25,9 +25,10 @@ public:
     }
 
     static void setFilePath(const char* fileName) {
-        if (getFileStatic() == nullptr) {
-            getFileStatic() = fopen(fileName, "w");
+        if (getFileStatic() != nullptr) {
+            fclose(getFileStatic());
         }
+        getFileStatic() = fopen(fileName, "w");
         assert(getFileStatic() != nullptr);
     }
 


### PR DESCRIPTION
Allows changing file being used for logging.