### PR TITLE
Add timestamp to console output

### DIFF
--- a/include/ivi-logging-common.h
+++ b/include/ivi-logging-common.h
@@ -115,12 +115,17 @@ public:
 		return m_enableThreadInfo;
 	}
 
+	bool isTimestampEnabled() const {
+		return m_enableTimestamp;
+	}
+
 	void registerContext();
 
 private:
 
 	static bool m_enableSourceCodeLocationInfo;
 	static bool m_enableThreadInfo;
+	static bool m_enableTimestamp;
 	static bool s_initialized;
 
 };

--- a/include/ivi-logging-console.h
+++ b/include/ivi-logging-console.h
@@ -3,11 +3,14 @@
 #include "ivi-logging-common.h"
 #include "stdio.h"
 #include <mutex>
+#include <chrono>
 #include "ivi-logging-utils.h"
 
 namespace logging
 {
 
+static const std::chrono::time_point<std::chrono::steady_clock>
+	m_start = std::chrono::steady_clock::now();
 class StreamLogData;
 class ConsoleLogData;
 
@@ -139,6 +142,7 @@ class StreamLogData : public LogData
 	static constexpr const char *DEFAULT_SUFFIX_WITH_FILE_LOCATION = " [ %.2i | %s / %s - %d ]";
 	static constexpr const char *DEFAULT_SUFFIX_WITH_SHORT_FILE_LOCATION_WITHOUT_FUNCTION = " | %s%.0s:%d ";
 	static constexpr const char *DEFAULT_THREAD_NAME_SUFFIX = "| %.2i / %s ";
+	static constexpr const char *DEFAULT_TIMESTAMP_SUFFIX = "| %luns";
 	static constexpr const char *DEFAULT_SUFFIX_WITH_SHORT_FILE_LOCATION_WITHOUT_FUNCTION_WITH_THREAD_NAME = " [ %s%.0s - %d | %.2i-%.16s ]";
 	static constexpr const char *DEFAULT_SUFFIX_WITHOUT_FILE_LOCATION = "";
 
@@ -204,6 +208,11 @@ class StreamLogData : public LogData
 		if (m_context->isThreadInfoEnabled())
 		{
 			writeFormatted(array, m_suffixThreadNameFormat, getThreadInformation().getID(), getThreadInformation().getName());
+		}
+		if (m_context->isTimestampEnabled())
+		{
+			auto diff = std::chrono::steady_clock::now() - m_start;
+			writeFormatted(array, m_suffixTimestampFormat, diff.count());
 		}
 		return array;
 	}
@@ -290,6 +299,7 @@ class StreamLogData : public LogData
 	//	const char* m_suffixFormat = DEFAULT_SUFFIX_WITH_SHORT_FILE_LOCATION_WITHOUT_FUNCTION_WITH_THREAD_NAME;
 	const char *m_suffixFormat = DEFAULT_SUFFIX_WITH_SHORT_FILE_LOCATION_WITHOUT_FUNCTION;
 	const char *m_suffixThreadNameFormat = DEFAULT_THREAD_NAME_SUFFIX;
+	const char *m_suffixTimestampFormat = DEFAULT_TIMESTAMP_SUFFIX;
 };
 
 inline FILE *ConsoleLogContext::getFile(StreamLogData &data)

--- a/src/ivi-logging.cpp
+++ b/src/ivi-logging.cpp
@@ -158,12 +158,14 @@ void LogContextBase::registerContext()
     {
         m_enableSourceCodeLocationInfo = readEnvVarAsBool("LOGGING_ENABLE_SOURCE_CODE_INFORMATION");
         m_enableThreadInfo = readEnvVarAsBool("LOGGING_ENABLE_THREAD_INFORMATION");
+        m_enableTimestamp = readEnvVarAsBool("LOGGING_ENABLE_TIMESTAMP");
         s_initialized = true;
     }
 }
 
 bool LogContextBase::m_enableSourceCodeLocationInfo;
 bool LogContextBase::m_enableThreadInfo;
+bool LogContextBase::m_enableTimestamp;
 bool LogContextBase::s_initialized;
 
 ConsoleLogContext::ConsoleLogContext()


### PR DESCRIPTION
Followed strategy to read from environment variable.

To enable timestamps, run the following command:
`export LOGGING_ENABLE_TIMESTAMP=1`
